### PR TITLE
fix(wdio): type configs as WebdriverIO.Config instead of Options.Testrunner

### DIFF
--- a/packages/dioxus/wdio.conf.ts
+++ b/packages/dioxus/wdio.conf.ts
@@ -1,7 +1,6 @@
-import type { Options } from '@wdio/types';
 import { baseConfig, buildDioxusCapability, dioxusService, logsDir, visualService } from './wdio.base.conf.ts';
 
-export const config: Options.Testrunner = {
+export const config: WebdriverIO.Config = {
   ...baseConfig,
   specs: ['./test/**/*.spec.ts'],
   exclude: [

--- a/packages/dioxus/wdio.multiremote.conf.ts
+++ b/packages/dioxus/wdio.multiremote.conf.ts
@@ -1,7 +1,6 @@
-import type { Options } from '@wdio/types';
 import { baseConfig, buildMultiremoteCapabilities, dioxusService, logsDir } from './wdio.base.conf.ts';
 
-export const config: Options.Testrunner = {
+export const config: WebdriverIO.MultiremoteConfig = {
   ...baseConfig,
   specs: ['./test/multiremote/**/*.spec.ts'],
   capabilities: buildMultiremoteCapabilities(),

--- a/packages/dioxus/wdio.window.conf.ts
+++ b/packages/dioxus/wdio.window.conf.ts
@@ -1,7 +1,6 @@
-import type { Options } from '@wdio/types';
 import { baseConfig, buildDioxusCapability, dioxusService, logsDir } from './wdio.base.conf.ts';
 
-export const config: Options.Testrunner = {
+export const config: WebdriverIO.Config = {
   ...baseConfig,
   specs: ['./test/window.spec.ts'],
   capabilities: [buildDioxusCapability()],

--- a/packages/electron-builder/wdio.conf.ts
+++ b/packages/electron-builder/wdio.conf.ts
@@ -1,4 +1,3 @@
-import type { Options } from '@wdio/types';
 import {
   baseConfig,
   buildElectronCapability,
@@ -7,7 +6,7 @@ import {
   visualService,
 } from './wdio.base.conf.ts';
 
-export const config: Options.Testrunner = {
+export const config: WebdriverIO.Config = {
   ...baseConfig,
   specs: ['./test/*.spec.ts'],
   exclude: [

--- a/packages/electron-builder/wdio.deeplink.conf.ts
+++ b/packages/electron-builder/wdio.deeplink.conf.ts
@@ -1,4 +1,3 @@
-import type { Options } from '@wdio/types';
 import { baseConfig, buildElectronCapability, electronService, logsDir } from './wdio.base.conf.ts';
 
 /**
@@ -6,7 +5,7 @@ import { baseConfig, buildElectronCapability, electronService, logsDir } from '.
  * handler (testapp://) can register and route URLs back via single-instance
  * lock + open-url events. Script mode is unsupported (use the binary build).
  */
-export const config: Options.Testrunner = {
+export const config: WebdriverIO.Config = {
   ...baseConfig,
   specs: ['./test/deeplink.spec.ts'],
   capabilities: [buildElectronCapability()],

--- a/packages/electron-builder/wdio.multiremote.conf.ts
+++ b/packages/electron-builder/wdio.multiremote.conf.ts
@@ -1,7 +1,6 @@
-import type { Options } from '@wdio/types';
 import { baseConfig, buildMultiremoteCapabilities, electronService, logsDir } from './wdio.base.conf.ts';
 
-export const config: Options.Testrunner = {
+export const config: WebdriverIO.MultiremoteConfig = {
   ...baseConfig,
   specs: ['./test/multiremote/**/*.spec.ts'],
   capabilities: buildMultiremoteCapabilities(),

--- a/packages/electron-builder/wdio.window.conf.ts
+++ b/packages/electron-builder/wdio.window.conf.ts
@@ -1,4 +1,3 @@
-import type { Options } from '@wdio/types';
 import { baseConfig, buildElectronCapability, electronService, logsDir } from './wdio.base.conf.ts';
 
 // Tells main/index.ts to spawn a splash window before showing main, so the
@@ -6,7 +5,7 @@ import { baseConfig, buildElectronCapability, electronService, logsDir } from '.
 // `.switch-main-window` button.
 process.env.ENABLE_SPLASH_WINDOW = 'true';
 
-export const config: Options.Testrunner = {
+export const config: WebdriverIO.Config = {
   ...baseConfig,
   specs: ['./test/window.spec.ts'],
   capabilities: [buildElectronCapability()],

--- a/packages/electron-forge/wdio.conf.ts
+++ b/packages/electron-forge/wdio.conf.ts
@@ -1,4 +1,3 @@
-import type { Options } from '@wdio/types';
 import {
   baseConfig,
   buildElectronCapability,
@@ -7,7 +6,7 @@ import {
   visualService,
 } from './wdio.base.conf.ts';
 
-export const config: Options.Testrunner = {
+export const config: WebdriverIO.Config = {
   ...baseConfig,
   specs: ['./test/*.spec.ts'],
   exclude: [

--- a/packages/electron-forge/wdio.deeplink.conf.ts
+++ b/packages/electron-forge/wdio.deeplink.conf.ts
@@ -1,4 +1,3 @@
-import type { Options } from '@wdio/types';
 import { baseConfig, buildElectronCapability, electronService, logsDir } from './wdio.base.conf.ts';
 
 /**
@@ -6,7 +5,7 @@ import { baseConfig, buildElectronCapability, electronService, logsDir } from '.
  * handler (testapp://) can register and route URLs back via single-instance
  * lock + open-url events. Script mode is unsupported (use the binary build).
  */
-export const config: Options.Testrunner = {
+export const config: WebdriverIO.Config = {
   ...baseConfig,
   specs: ['./test/deeplink.spec.ts'],
   capabilities: [buildElectronCapability()],

--- a/packages/electron-forge/wdio.multiremote.conf.ts
+++ b/packages/electron-forge/wdio.multiremote.conf.ts
@@ -1,7 +1,6 @@
-import type { Options } from '@wdio/types';
 import { baseConfig, buildMultiremoteCapabilities, electronService, logsDir } from './wdio.base.conf.ts';
 
-export const config: Options.Testrunner = {
+export const config: WebdriverIO.MultiremoteConfig = {
   ...baseConfig,
   specs: ['./test/multiremote/**/*.spec.ts'],
   capabilities: buildMultiremoteCapabilities(),

--- a/packages/electron-forge/wdio.window.conf.ts
+++ b/packages/electron-forge/wdio.window.conf.ts
@@ -1,4 +1,3 @@
-import type { Options } from '@wdio/types';
 import { baseConfig, buildElectronCapability, electronService, logsDir } from './wdio.base.conf.ts';
 
 // Tells main/index.ts to spawn a splash window before showing main, so the
@@ -6,7 +5,7 @@ import { baseConfig, buildElectronCapability, electronService, logsDir } from '.
 // `.switch-main-window` button.
 process.env.ENABLE_SPLASH_WINDOW = 'true';
 
-export const config: Options.Testrunner = {
+export const config: WebdriverIO.Config = {
   ...baseConfig,
   specs: ['./test/window.spec.ts'],
   capabilities: [buildElectronCapability()],

--- a/packages/electron-script/wdio.conf.ts
+++ b/packages/electron-script/wdio.conf.ts
@@ -1,4 +1,3 @@
-import type { Options } from '@wdio/types';
 import {
   baseConfig,
   buildElectronCapability,
@@ -7,7 +6,7 @@ import {
   visualService,
 } from './wdio.base.conf.ts';
 
-export const config: Options.Testrunner = {
+export const config: WebdriverIO.Config = {
   ...baseConfig,
   specs: ['./test/*.spec.ts'],
   exclude: [

--- a/packages/electron-script/wdio.multiremote.conf.ts
+++ b/packages/electron-script/wdio.multiremote.conf.ts
@@ -1,7 +1,6 @@
-import type { Options } from '@wdio/types';
 import { baseConfig, buildMultiremoteCapabilities, electronService, logsDir } from './wdio.base.conf.ts';
 
-export const config: Options.Testrunner = {
+export const config: WebdriverIO.MultiremoteConfig = {
   ...baseConfig,
   specs: ['./test/multiremote/**/*.spec.ts'],
   capabilities: buildMultiremoteCapabilities(),

--- a/packages/electron-script/wdio.window.conf.ts
+++ b/packages/electron-script/wdio.window.conf.ts
@@ -1,4 +1,3 @@
-import type { Options } from '@wdio/types';
 import { baseConfig, buildElectronCapability, electronService, logsDir } from './wdio.base.conf.ts';
 
 // Tells main/index.ts to spawn a splash window before showing main, so the
@@ -6,7 +5,7 @@ import { baseConfig, buildElectronCapability, electronService, logsDir } from '.
 // `.switch-main-window` button.
 process.env.ENABLE_SPLASH_WINDOW = 'true';
 
-export const config: Options.Testrunner = {
+export const config: WebdriverIO.Config = {
   ...baseConfig,
   specs: ['./test/window.spec.ts'],
   capabilities: [buildElectronCapability()],

--- a/packages/react-native/wdio.conf.ts
+++ b/packages/react-native/wdio.conf.ts
@@ -1,4 +1,3 @@
-import type { Options } from '@wdio/types';
 import {
   appiumService,
   baseConfig,
@@ -10,7 +9,7 @@ import {
 
 const outputDir = logsDir('standard');
 
-export const config: Options.Testrunner = {
+export const config: WebdriverIO.Config = {
   ...baseConfig,
   specs: ['./test/**/*.spec.ts'],
   exclude: [

--- a/packages/react-native/wdio.contexts.conf.ts
+++ b/packages/react-native/wdio.contexts.conf.ts
@@ -1,4 +1,3 @@
-import type { Options } from '@wdio/types';
 import {
   appiumService,
   baseConfig,
@@ -10,7 +9,7 @@ import {
 
 const outputDir = logsDir('contexts');
 
-export const config: Options.Testrunner = {
+export const config: WebdriverIO.Config = {
   ...baseConfig,
   // Mobile "windows" are Appium contexts (NATIVE_APP / WEBVIEW_*) — the window→contexts rename.
   specs: ['./test/contexts.spec.ts'],

--- a/packages/react-native/wdio.deeplink.conf.ts
+++ b/packages/react-native/wdio.deeplink.conf.ts
@@ -1,4 +1,3 @@
-import type { Options } from '@wdio/types';
 import {
   appiumService,
   baseConfig,
@@ -10,7 +9,7 @@ import {
 
 const outputDir = logsDir('deeplink');
 
-export const config: Options.Testrunner = {
+export const config: WebdriverIO.Config = {
   ...baseConfig,
   specs: ['./test/deeplink.spec.ts'],
   capabilities: [buildReactNativeCapability()],

--- a/packages/tauri/wdio.crabnebula.conf.ts
+++ b/packages/tauri/wdio.crabnebula.conf.ts
@@ -1,4 +1,3 @@
-import type { Options } from '@wdio/types';
 import {
   baseConfig,
   buildTauriCapability,
@@ -7,7 +6,7 @@ import {
   visualService,
 } from './wdio.base.conf.ts';
 
-export const config: Options.Testrunner = {
+export const config: WebdriverIO.Config = {
   ...baseConfig,
   specs: ['./test/**/*.spec.ts'],
   exclude: [

--- a/packages/tauri/wdio.crabnebula.deeplink.conf.ts
+++ b/packages/tauri/wdio.crabnebula.deeplink.conf.ts
@@ -1,9 +1,8 @@
-import type { Options } from '@wdio/types';
 import { baseConfig, buildTauriCapability, logsDir, tauriService } from './wdio.base.conf.ts';
 
 process.env.ENABLE_SINGLE_INSTANCE = 'true';
 
-export const config: Options.Testrunner = {
+export const config: WebdriverIO.Config = {
   ...baseConfig,
   specs: ['./test/deeplink.spec.ts'],
   capabilities: [buildTauriCapability('crabnebula')],

--- a/packages/tauri/wdio.crabnebula.multiremote.conf.ts
+++ b/packages/tauri/wdio.crabnebula.multiremote.conf.ts
@@ -1,7 +1,6 @@
-import type { Options } from '@wdio/types';
 import { baseConfig, buildMultiremoteCapabilities, logsDir, tauriService } from './wdio.base.conf.ts';
 
-export const config: Options.Testrunner = {
+export const config: WebdriverIO.MultiremoteConfig = {
   ...baseConfig,
   specs: ['./test/multiremote/**/*.spec.ts'],
   // multiremote/logging.spec.ts auto-skips on CrabNebula (test-runner-backend

--- a/packages/tauri/wdio.crabnebula.window.conf.ts
+++ b/packages/tauri/wdio.crabnebula.window.conf.ts
@@ -1,9 +1,8 @@
-import type { Options } from '@wdio/types';
 import { baseConfig, buildTauriCapability, logsDir, tauriService } from './wdio.base.conf.ts';
 
 process.env.ENABLE_SPLASH_WINDOW = 'true';
 
-export const config: Options.Testrunner = {
+export const config: WebdriverIO.Config = {
   ...baseConfig,
   specs: ['./test/window.spec.ts'],
   capabilities: [buildTauriCapability('crabnebula')],

--- a/packages/tauri/wdio.embedded.conf.ts
+++ b/packages/tauri/wdio.embedded.conf.ts
@@ -1,4 +1,3 @@
-import type { Options } from '@wdio/types';
 import {
   baseConfig,
   buildTauriCapability,
@@ -11,7 +10,7 @@ import {
 // tauri-plugin-wdio-webdriver. Signal the plugin to start its server.
 process.env.WDIO_EMBEDDED_SERVER = 'true';
 
-export const config: Options.Testrunner = {
+export const config: WebdriverIO.Config = {
   ...baseConfig,
   specs: ['./test/**/*.spec.ts'],
   exclude: [

--- a/packages/tauri/wdio.embedded.deeplink.conf.ts
+++ b/packages/tauri/wdio.embedded.deeplink.conf.ts
@@ -1,4 +1,3 @@
-import type { Options } from '@wdio/types';
 import { baseConfig, buildTauriCapability, logsDir, tauriService } from './wdio.base.conf.ts';
 
 process.env.WDIO_EMBEDDED_SERVER = 'true';
@@ -7,7 +6,7 @@ process.env.WDIO_EMBEDDED_SERVER = 'true';
 // the original instance instead of starting a new process.
 process.env.ENABLE_SINGLE_INSTANCE = 'true';
 
-export const config: Options.Testrunner = {
+export const config: WebdriverIO.Config = {
   ...baseConfig,
   specs: ['./test/deeplink.spec.ts'],
   capabilities: [buildTauriCapability('embedded')],

--- a/packages/tauri/wdio.embedded.multiremote.conf.ts
+++ b/packages/tauri/wdio.embedded.multiremote.conf.ts
@@ -1,9 +1,8 @@
-import type { Options } from '@wdio/types';
 import { baseConfig, buildMultiremoteCapabilities, logsDir, tauriService } from './wdio.base.conf.ts';
 
 process.env.WDIO_EMBEDDED_SERVER = 'true';
 
-export const config: Options.Testrunner = {
+export const config: WebdriverIO.MultiremoteConfig = {
   ...baseConfig,
   specs: ['./test/multiremote/**/*.spec.ts'],
   capabilities: buildMultiremoteCapabilities('embedded'),

--- a/packages/tauri/wdio.embedded.window.conf.ts
+++ b/packages/tauri/wdio.embedded.window.conf.ts
@@ -1,11 +1,10 @@
-import type { Options } from '@wdio/types';
 import { baseConfig, buildTauriCapability, logsDir, tauriService } from './wdio.base.conf.ts';
 
 process.env.WDIO_EMBEDDED_SERVER = 'true';
 // Tells main.rs to spawn the splash window before main.
 process.env.ENABLE_SPLASH_WINDOW = 'true';
 
-export const config: Options.Testrunner = {
+export const config: WebdriverIO.Config = {
   ...baseConfig,
   specs: ['./test/window.spec.ts'],
   capabilities: [buildTauriCapability('embedded')],

--- a/packages/tauri/wdio.official.conf.ts
+++ b/packages/tauri/wdio.official.conf.ts
@@ -1,4 +1,3 @@
-import type { Options } from '@wdio/types';
 import {
   baseConfig,
   buildTauriCapability,
@@ -10,7 +9,7 @@ import {
 
 skipOnMacOS('Tauri official driver is not supported on macOS');
 
-export const config: Options.Testrunner = {
+export const config: WebdriverIO.Config = {
   ...baseConfig,
   specs: ['./test/**/*.spec.ts'],
   exclude: [

--- a/packages/tauri/wdio.official.deeplink.conf.ts
+++ b/packages/tauri/wdio.official.deeplink.conf.ts
@@ -1,11 +1,10 @@
-import type { Options } from '@wdio/types';
 import { baseConfig, buildTauriCapability, logsDir, skipOnMacOS, tauriService } from './wdio.base.conf.ts';
 
 skipOnMacOS('Tauri official driver is not supported on macOS');
 
 process.env.ENABLE_SINGLE_INSTANCE = 'true';
 
-export const config: Options.Testrunner = {
+export const config: WebdriverIO.Config = {
   ...baseConfig,
   specs: ['./test/deeplink.spec.ts'],
   capabilities: [buildTauriCapability('official')],

--- a/packages/tauri/wdio.official.multiremote.conf.ts
+++ b/packages/tauri/wdio.official.multiremote.conf.ts
@@ -1,9 +1,8 @@
-import type { Options } from '@wdio/types';
 import { baseConfig, buildMultiremoteCapabilities, logsDir, skipOnMacOS, tauriService } from './wdio.base.conf.ts';
 
 skipOnMacOS('Tauri official driver is not supported on macOS');
 
-export const config: Options.Testrunner = {
+export const config: WebdriverIO.MultiremoteConfig = {
   ...baseConfig,
   specs: ['./test/multiremote/**/*.spec.ts'],
   capabilities: buildMultiremoteCapabilities('official'),

--- a/packages/tauri/wdio.official.window.conf.ts
+++ b/packages/tauri/wdio.official.window.conf.ts
@@ -1,11 +1,10 @@
-import type { Options } from '@wdio/types';
 import { baseConfig, buildTauriCapability, logsDir, skipOnMacOS, tauriService } from './wdio.base.conf.ts';
 
 skipOnMacOS('Tauri official driver is not supported on macOS');
 
 process.env.ENABLE_SPLASH_WINDOW = 'true';
 
-export const config: Options.Testrunner = {
+export const config: WebdriverIO.Config = {
   ...baseConfig,
   specs: ['./test/window.spec.ts'],
   capabilities: [buildTauriCapability('official')],


### PR DESCRIPTION
Addresses the core of #143.

## Problem
Every `wdio.*.conf.ts` annotated `const config: Options.Testrunner = {…}`, but `Options.Testrunner` carries no `capabilities` (it's `Testrunner` + hooks; `capabilities` lives on `WebdriverIO.Config` = `Testrunner & WithRequestedTestrunnerCapabilities`). So `tsc` flagged **TS2353 — "'capabilities' does not exist in type 'Testrunner'"** on all 29 configs across every package. Latent (no typecheck gate), but noise in IDEs and a blocker to adding one.

## Fix
Annotate configs with the capabilities-bearing types:
- `WebdriverIO.Config` — 22 single-session configs (`capabilities: [...]`)
- `WebdriverIO.MultiremoteConfig` — 7 multiremote configs (`capabilities: { browserA, … }`)

Both are global (ambient) types, so the now-unused `import type { Options } from '@wdio/types'` is dropped from each. `wdio.base.conf.ts` keeps `Partial<Options.Testrunner>` (baseConfig has no `capabilities`).

## Result
- **0 `Testrunner` errors repo-wide** (was 29).
- **electron-builder / electron-forge / electron-script / react-native are now fully tsc-clean.**
- `dioxus` and `tauri` retain the separate, pre-existing tsc errors that #143 explicitly lists as out-of-scope follow-ups (`unknown` execute returns in the *converged* spec bodies, the `@wdio/visual-service` augmentation, `Object.hasOwn` lib level, and `wdio-video-reporter` / root `wdio.*.shared.ts` module resolution). Left out so this PR stays focused on the Testrunner quirk; a typecheck CI gate can land once those are cleared.

No runtime/behaviour change — annotations only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a TypeScript type annotation issue across 29 WebdriverIO config files by replacing `Options.Testrunner` (which lacks a `capabilities` field) with the more precise `WebdriverIO.Config` or `WebdriverIO.MultiremoteConfig` ambient types. The now-unused `import type { Options } from '@wdio/types'` is removed from each config; `wdio.base.conf.ts` correctly retains `Partial<Options.Testrunner>` since the shared base object carries no `capabilities`.

- **22 single-session configs** are annotated as `WebdriverIO.Config` (array capabilities pattern); **7 multiremote configs** are annotated as `WebdriverIO.MultiremoteConfig` (object capabilities pattern) — both are correct ambient type aliases in the WebdriverIO global namespace.
- No runtime or behavioural changes are introduced; this is a pure type-annotation fix that eliminates 29 TS2353 errors repo-wide and unblocks adding a typecheck CI gate.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — annotation-only change with no runtime impact.

Every changed file makes the same mechanical substitution: swapping `Options.Testrunner` for the correct ambient type and dropping the now-unnecessary import. The base config is left as `Partial<Options.Testrunner>`, which remains structurally correct since it carries no `capabilities`. No logic, configuration values, or runtime behaviour is altered.

No files require special attention; the change is uniform across all 29 configs.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/electron-builder/wdio.conf.ts | Drops unused `Options` import; annotates config as `WebdriverIO.Config` — correct for array-capabilities single-session config. |
| packages/electron-builder/wdio.multiremote.conf.ts | Drops unused `Options` import; annotates config as `WebdriverIO.MultiremoteConfig` — correct for object-keyed multiremote capabilities. |
| packages/electron-builder/wdio.deeplink.conf.ts | Drops unused `Options` import; annotates config as `WebdriverIO.Config` — correct single-session type. |
| packages/electron-builder/wdio.window.conf.ts | Drops unused `Options` import; annotates config as `WebdriverIO.Config` — correct single-session type. |
| packages/electron-forge/wdio.conf.ts | Drops unused `Options` import; annotates config as `WebdriverIO.Config` — correct single-session type. |
| packages/electron-forge/wdio.multiremote.conf.ts | Drops unused `Options` import; annotates config as `WebdriverIO.MultiremoteConfig` — correct multiremote type. |
| packages/electron-forge/wdio.deeplink.conf.ts | Drops unused `Options` import; annotates config as `WebdriverIO.Config` — correct single-session type. |
| packages/electron-forge/wdio.window.conf.ts | Drops unused `Options` import; annotates config as `WebdriverIO.Config` — correct single-session type. |
| packages/electron-script/wdio.conf.ts | Drops unused `Options` import; annotates config as `WebdriverIO.Config` — correct single-session type. |
| packages/electron-script/wdio.multiremote.conf.ts | Drops unused `Options` import; annotates config as `WebdriverIO.MultiremoteConfig` — correct multiremote type. |
| packages/electron-script/wdio.window.conf.ts | Drops unused `Options` import; annotates config as `WebdriverIO.Config` — correct single-session type. |
| packages/react-native/wdio.conf.ts | Drops unused `Options` import; annotates config as `WebdriverIO.Config` — correct single-session type. |
| packages/react-native/wdio.contexts.conf.ts | Drops unused `Options` import; annotates config as `WebdriverIO.Config` — correct single-session type. |
| packages/react-native/wdio.deeplink.conf.ts | Drops unused `Options` import; annotates config as `WebdriverIO.Config` — correct single-session type. |
| packages/dioxus/wdio.conf.ts | Drops unused `Options` import; annotates config as `WebdriverIO.Config` — correct single-session type. |
| packages/dioxus/wdio.multiremote.conf.ts | Drops unused `Options` import; annotates config as `WebdriverIO.MultiremoteConfig` — correct multiremote type. |
| packages/dioxus/wdio.window.conf.ts | Drops unused `Options` import; annotates config as `WebdriverIO.Config` — correct single-session type. |
| packages/tauri/wdio.crabnebula.conf.ts | Drops unused `Options` import; annotates config as `WebdriverIO.Config` — correct single-session type. |
| packages/tauri/wdio.crabnebula.deeplink.conf.ts | Drops unused `Options` import; annotates config as `WebdriverIO.Config` — correct single-session type. |
| packages/tauri/wdio.crabnebula.multiremote.conf.ts | Drops unused `Options` import; annotates config as `WebdriverIO.MultiremoteConfig` — correct multiremote type. |
| packages/tauri/wdio.crabnebula.window.conf.ts | Drops unused `Options` import; annotates config as `WebdriverIO.Config` — correct single-session type. |
| packages/tauri/wdio.embedded.conf.ts | Drops unused `Options` import; annotates config as `WebdriverIO.Config` — correct single-session type. |
| packages/tauri/wdio.embedded.deeplink.conf.ts | Drops unused `Options` import; annotates config as `WebdriverIO.Config` — correct single-session type. |
| packages/tauri/wdio.embedded.multiremote.conf.ts | Drops unused `Options` import; annotates config as `WebdriverIO.MultiremoteConfig` — correct multiremote type. |
| packages/tauri/wdio.embedded.window.conf.ts | Drops unused `Options` import; annotates config as `WebdriverIO.Config` — correct single-session type. |
| packages/tauri/wdio.official.conf.ts | Drops unused `Options` import; annotates config as `WebdriverIO.Config` — correct single-session type. |
| packages/tauri/wdio.official.deeplink.conf.ts | Drops unused `Options` import; annotates config as `WebdriverIO.Config` — correct single-session type. |
| packages/tauri/wdio.official.multiremote.conf.ts | Drops unused `Options` import; annotates config as `WebdriverIO.MultiremoteConfig` — correct multiremote type. |
| packages/tauri/wdio.official.window.conf.ts | Drops unused `Options` import; annotates config as `WebdriverIO.Config` — correct single-session type. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["wdio.base.conf.ts\n(baseConfig: Partial<Options.Testrunner>)"]

    A -->|"...baseConfig spread"| B["Single-session configs x22\nconfig: WebdriverIO.Config\n(capabilities: WebdriverIO.Capabilities[])"]
    A -->|"...baseConfig spread"| C["Multiremote configs x7\nconfig: WebdriverIO.MultiremoteConfig\n(capabilities: RequestedMultiremoteCapabilities)"]

    subgraph Type_hierarchy
        D["Options.Testrunner\n(no capabilities)"]
        E["WebdriverIO.Config\n= Testrunner & WithRequestedTestrunnerCapabilities"]
        F["WebdriverIO.MultiremoteConfig\n(object capabilities)"]
        D -->|"extended by"| E
        D -->|"extended by"| F
    end

    B -.->|"typed as"| E
    C -.->|"typed as"| F
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["wdio.base.conf.ts\n(baseConfig: Partial<Options.Testrunner>)"]

    A -->|"...baseConfig spread"| B["Single-session configs x22\nconfig: WebdriverIO.Config\n(capabilities: WebdriverIO.Capabilities[])"]
    A -->|"...baseConfig spread"| C["Multiremote configs x7\nconfig: WebdriverIO.MultiremoteConfig\n(capabilities: RequestedMultiremoteCapabilities)"]

    subgraph Type_hierarchy
        D["Options.Testrunner\n(no capabilities)"]
        E["WebdriverIO.Config\n= Testrunner & WithRequestedTestrunnerCapabilities"]
        F["WebdriverIO.MultiremoteConfig\n(object capabilities)"]
        D -->|"extended by"| E
        D -->|"extended by"| F
    end

    B -.->|"typed as"| E
    C -.->|"typed as"| F
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(wdio): type configs as WebdriverIO.C..."](https://github.com/goosewobbler/wdio-desktop-mobile-example/commit/19a40263bdce5916e197f5791537b7485dc16ef7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39343483)</sub>

<!-- /greptile_comment -->