### PR TITLE
chore: standardize on Node 22 across CI, engines, and docs

### DIFF
--- a/.github/workflows/_ci.reusable.yml
+++ b/.github/workflows/_ci.reusable.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        node-version: [20.x]
+        node-version: [22.x]
         package: [builder, forge, script]
         test-type: [standard, multiremote, deeplink, standalone, window, visual, video]
         exclude:
@@ -92,7 +92,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        node-version: [20.x]
+        node-version: [22.x]
         test-type: [standard, multiremote, standalone, window, visual, video]
         # No deeplink: the Dioxus fixture does not register the testapp://
         # protocol handler. Add a deeplink cell once the fixture supports it.
@@ -176,7 +176,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        node-version: [20.x]
+        node-version: [22.x]
         test-type: [standard, multiremote, deeplink, standalone, window, visual, video]
       fail-fast: false
 
@@ -249,7 +249,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        node-version: [20.x]
+        node-version: [22.x]
         test-type: [standard, multiremote, deeplink, standalone, window, visual, video]
         exclude:
           # On Linux+official (tauri-driver + WebKitGTK), @wdio/visual-service's
@@ -332,7 +332,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        node-version: [20.x]
+        node-version: [22.x]
         test-type: [standard, multiremote, deeplink, standalone, window, visual, video]
         exclude:
           # CrabNebula's macOS driver captures via OS-level Screen Recording

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ suite (out of scope for this manual-verification example).
 ## Prerequisites
 
 ### All Platforms
-- **Node.js** 18+ (the `react-native` package requires **22.12+**)
+- **Node.js** 22.12+
 - **pnpm** 10.x
 
 ### Tauri-Specific Requirements

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "turbo": "^2.9.6"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.12.0"
   },
   "lint-staged": {
     "**/*.{js,ts}": ["biome check --write --formatter-enabled=false --linter-enabled=true"],

--- a/packages/dioxus/README.md
+++ b/packages/dioxus/README.md
@@ -19,7 +19,7 @@ Manual-verification test package for [`@wdio/dioxus-service`](https://github.com
 ## Prerequisites
 
 ### All platforms
-- **Node.js** 18+
+- **Node.js** 22.12+
 - **pnpm** 10.x
 - **Rust** (latest stable) — [Install Rust](https://www.rust-lang.org/tools/install)
 

--- a/packages/dioxus/package.json
+++ b/packages/dioxus/package.json
@@ -37,6 +37,6 @@
     "webdriverio": "catalog:default"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.12.0"
   }
 }

--- a/packages/electron-builder/package.json
+++ b/packages/electron-builder/package.json
@@ -48,7 +48,7 @@
     "webdriverio": "catalog:default"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.12.0"
   },
   "build": {
     "appId": "com.wdio-desktop-mobile-example.electron-builder",

--- a/packages/electron-forge/package.json
+++ b/packages/electron-forge/package.json
@@ -48,6 +48,6 @@
     "webdriverio": "catalog:default"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.12.0"
   }
 }

--- a/packages/electron-script/package.json
+++ b/packages/electron-script/package.json
@@ -44,6 +44,6 @@
     "webdriverio": "catalog:default"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.12.0"
   }
 }

--- a/packages/react-native/app/package.json
+++ b/packages/react-native/app/package.json
@@ -27,6 +27,6 @@
     "typescript": "5.0.4"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22.12.0"
   }
 }

--- a/packages/tauri/README.md
+++ b/packages/tauri/README.md
@@ -11,7 +11,7 @@ This package provides a Tauri application with comprehensive WebdriverIO testing
 
 ## Prerequisites
 
-- Node.js 18+
+- Node.js 22.12+
 - Rust (latest stable)
 - Platform-specific dependencies (see main README)
 

--- a/packages/tauri/package.json
+++ b/packages/tauri/package.json
@@ -71,6 +71,6 @@
     "webdriverio": "catalog:default"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.12.0"
   }
 }


### PR DESCRIPTION
Standardizes the repo on **Node 22** everywhere.

Node 22 is already the floor the `react-native` service requires (`>=22.12`), the RN CI jobs already run on `22.x`, and Node 20 is heading for end-of-life — so this aligns the rest of the repo.

## Changes
- **CI** (`_ci.reusable.yml`): every job matrix `node-version: [20.x] → [22.x]` (electron, dioxus, tauri-embedded/official/crabnebula). The two react-native jobs were already `22.x`, so all 7 jobs now run on Node 22.
- **`engines.node`**: root + `dioxus` + `electron-builder/forge/script` + `tauri` + the RN fixture manifest (`app/package.json`) `>=18 → >=22.12.0`. The `react-native` package was already `>=22.12.0`.
- **Docs**: root, `dioxus`, and `tauri` READMEs updated to **Node.js 22.12+**.

## Notes
- `>=22.12.0` (not `>=22.0.0`) to match the existing react-native floor and Node 22 LTS; it's also what the `22.x` CI runners resolve to.
- Engines are declarative and the lockfile is node-version-independent, so there's no lockfile or dependency-resolution change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR standardizes the entire repository on Node.js 22.12+ by updating CI job matrices, `engines.node` fields across all packages, and prerequisite documentation. Node 22 was already the minimum required by the `react-native` service; this change brings every other package and workflow into alignment.

- **CI** (`_ci.reusable.yml`): Five job matrices updated from `node-version: [20.x]` to `[22.x]`; the two react-native jobs were already at `22.x`, so all 7 jobs now run uniformly on Node 22.
- **`engines.node`**: All packages (root, dioxus, electron-builder/forge/script, tauri, react-native/app) updated from `>=18.0.0` / `>=18` to `>=22.12.0`. The parent `react-native` package was already correct.
- **Docs**: Root, dioxus, and tauri READMEs updated to reflect the new `22.12+` requirement; electron package READMEs contain no Node version references and needed no changes.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — every change is a mechanical version string update with no logic or dependency changes.

All 11 files contain only version string updates: CI matrix node versions, package.json engines fields, and README prerequisites. The changes are consistent across the board, the react-native parent package was already at the target version confirming the constraint is correct, and the electron READMEs had no Node version references to update. No code logic, lockfiles, or runtime behavior is affected.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/_ci.reusable.yml | Updates 5 job matrices from node-version [20.x] to [22.x]; the two react-native jobs were already at 22.x, making all 7 jobs consistent. |
| package.json | Root engines.node bumped from >=18.0.0 to >=22.12.0, aligning with the new repo-wide minimum. |
| README.md | Prerequisites section simplified from 'Node.js 18+ (react-native requires 22.12+)' to 'Node.js 22.12+' — accurate and less confusing. |
| packages/dioxus/package.json | engines.node bumped from >=18.0.0 to >=22.12.0. |
| packages/electron-builder/package.json | engines.node bumped from >=18.0.0 to >=22.12.0. |
| packages/electron-forge/package.json | engines.node bumped from >=18.0.0 to >=22.12.0. |
| packages/electron-script/package.json | engines.node bumped from >=18.0.0 to >=22.12.0. |
| packages/react-native/app/package.json | engines.node updated from >=18 to >=22.12.0, matching the parent react-native package which was already at >=22.12.0. |
| packages/tauri/package.json | engines.node bumped from >=18.0.0 to >=22.12.0. |
| packages/dioxus/README.md | Prerequisites section updated from 'Node.js 18+' to 'Node.js 22.12+'. |
| packages/tauri/README.md | Prerequisites section updated from 'Node.js 18+' to 'Node.js 22.12+'. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph Before
        A1[CI: electron jobs\nnode 20.x]
        A2[CI: dioxus jobs\nnode 20.x]
        A3[CI: tauri jobs\nnode 20.x]
        A4[CI: react-native jobs\nnode 22.x]
        B1[engines: root\n>=18.0.0]
        B2[engines: dioxus\n>=18.0.0]
        B3[engines: electron-*\n>=18.0.0]
        B4[engines: tauri\n>=18.0.0]
        B5[engines: react-native/app\n>=18]
        B6[engines: react-native\n>=22.12.0]
    end
    subgraph After
        C1[CI: ALL jobs\nnode 22.x]
        D1[engines: ALL packages\n>=22.12.0]
    end
    A1 --> C1
    A2 --> C1
    A3 --> C1
    A4 --> C1
    B1 --> D1
    B2 --> D1
    B3 --> D1
    B4 --> D1
    B5 --> D1
    B6 --> D1
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    subgraph Before
        A1[CI: electron jobs\nnode 20.x]
        A2[CI: dioxus jobs\nnode 20.x]
        A3[CI: tauri jobs\nnode 20.x]
        A4[CI: react-native jobs\nnode 22.x]
        B1[engines: root\n>=18.0.0]
        B2[engines: dioxus\n>=18.0.0]
        B3[engines: electron-*\n>=18.0.0]
        B4[engines: tauri\n>=18.0.0]
        B5[engines: react-native/app\n>=18]
        B6[engines: react-native\n>=22.12.0]
    end
    subgraph After
        C1[CI: ALL jobs\nnode 22.x]
        D1[engines: ALL packages\n>=22.12.0]
    end
    A1 --> C1
    A2 --> C1
    A3 --> C1
    A4 --> C1
    B1 --> D1
    B2 --> D1
    B3 --> D1
    B4 --> D1
    B5 --> D1
    B6 --> D1
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: standardize on Node 22 across CI,..."](https://github.com/goosewobbler/wdio-desktop-mobile-example/commit/742b1921abb693f731a0f74caf704d16d303a6c8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39344278)</sub>

<!-- /greptile_comment -->