### PR TITLE
ci(tauri): skip CrabNebula macOS cell on dependabot PRs

### DIFF
--- a/.github/workflows/_ci.reusable.yml
+++ b/.github/workflows/_ci.reusable.yml
@@ -329,6 +329,12 @@ jobs:
   tauri-crabnebula:
     name: tauri-crabnebula-${{ matrix.test-type }} (${{ matrix.os }}, ${{ matrix.node-version }})
     runs-on: ${{ matrix.os }}
+    env:
+      # Dependabot-triggered runs receive no repository secrets, so CN_API_KEY
+      # is empty there. Evaluate its presence into a boolean here (without
+      # exposing the value to every step) so the macOS run below — the only
+      # cell that requires the key — can be skipped on dependabot PRs.
+      HAS_CN_API_KEY: ${{ secrets.CN_API_KEY != '' }}
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
@@ -399,7 +405,11 @@ jobs:
           RUST_BACKTRACE: '1'
         run: xvfb-run --auto-servernum --server-args="-screen 0 1280x1024x16" pnpm run test:tauri:crabnebula:${{ matrix.test-type }}
       - name: Run Tauri CrabNebula tests
-        if: ${{ runner.os != 'Linux' }}
+        # macOS CrabNebula requires CN_API_KEY. Dependabot PRs can't access repo
+        # secrets, so skip just the macOS cell there (Windows needs no key and
+        # still runs). Any non-dependabot run with a missing key still fails
+        # loudly, surfacing a genuine secret misconfiguration.
+        if: ${{ runner.os != 'Linux' && !(runner.os == 'macOS' && github.actor == 'dependabot[bot]' && env.HAS_CN_API_KEY != 'true') }}
         env:
           CN_API_KEY: ${{ secrets.CN_API_KEY }}
           RUST_BACKTRACE: '1'


### PR DESCRIPTION
## Problem

Dependabot PRs (e.g. #147 `actions/checkout` v6→v7) show red because every macOS **CrabNebula** job fails in the service's `onPrepare` hook:

```
Error: CN_API_KEY environment variable is required for CrabNebula macOS testing.
  at TauriLaunchService.validateCrabNebulaPrerequisites (@wdio/tauri-service/dist/esm/index.js)
  at TauriLaunchService.onPrepare
```

This is **not** a `@wdio/tauri-service` bug and **not** a CrabNebula issue — the service is correctly failing fast on a missing prerequisite. The root cause is purely CI: **GitHub withholds repository secrets from dependabot-triggered runs**, so `secrets.CN_API_KEY` interpolates to empty.

**Proof by contrast:** on the scheduled `main` run (secrets available) all five macOS CrabNebula jobs pass; on the dependabot PR (no secrets) those same jobs fail at `onPrepare`. Linux/Windows CrabNebula jobs pass on dependabot because only the macOS driver requires the key.

## Fix

Gate **only the macOS CrabNebula cell** on `(macOS && dependabot && key absent)`:

- The secret's presence is evaluated into a job-level boolean `HAS_CN_API_KEY` (so `CN_API_KEY` itself isn't exposed to every step).
- Windows/Linux need no key and keep running on dependabot PRs.
- Any **non-dependabot** run with a missing key still fails loudly — a genuine secret misconfiguration is not masked.

## Note on upstream parity

Upstream `webdriverio/desktop-mobile` avoids this differently: it skips its **entire** CI pipeline for dependabot at the top level (`detect-changes` is gated `if: github.event.pull_request.user.login != 'dependabot[bot]'`), motivated by runner cost. This repo deliberately keeps the surgical per-step gate instead, so dependabot bumps (which modify these workflow files) still get validated across the matrix and report green checks — at the cost of diverging from upstream's blanket-skip pattern.

## After merge

Existing dependabot PRs reference the reusable workflow from their own branch ref, so they pick up this fix only after rebasing onto an updated `main`. Comment `@dependabot rebase` on the open `actions/checkout` and `actions/cache` PRs (or wait for their next scheduled rebase).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a targeted CI guard to skip the macOS CrabNebula test step when a dependabot-triggered run lacks the `CN_API_KEY` repository secret (which GitHub withholds from dependabot runs). The fix evaluates secret presence into a job-level boolean env var (`HAS_CN_API_KEY`) and uses it alongside `github.actor` and `runner.os` to gate only the macOS cell, leaving Windows and Linux unaffected.

- A job-level `env.HAS_CN_API_KEY` boolean is derived from `secrets.CN_API_KEY != ''`, exposing only the key's presence — not the value — to step conditions.
- The step `if` condition is extended to skip the run when all three are true: runner is macOS, actor is `dependabot[bot]`, and the key is absent; any non-dependabot run with a missing key still fails loudly.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge — the change is limited to a single CI step condition and a job-level env var; it does not affect application code or test logic.

The guard logic is correct: the three-part condition (macOS AND dependabot actor AND absent key) means Windows/Linux and all non-dependabot runs are completely unaffected. One minor nuance is that github.actor reflects who triggered the current run (or re-run), not the original commit author; a manual re-run of a dependabot workflow by a maintainer would flip github.actor away from dependabot[bot], but at that point secrets become available again anyway, so the observable behavior is still correct. The boolean secret-presence pattern is idiomatic for GitHub Actions.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/_ci.reusable.yml | Adds job-level HAS_CN_API_KEY env boolean and extends the macOS CrabNebula step condition to skip on dependabot PRs without a secret; logic is correct and minimal. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[tauri-crabnebula job starts] --> B{Linux runner?}
    B -- Yes --> C[Run via xvfb-run]
    B -- No --> D{macOS runner?}
    D -- No: Windows --> F[Run step\nWindows needs no key]
    D -- Yes --> G{actor is dependabot-bot?}
    G -- No --> H[Run step\nnon-dependabot, fails loudly if key missing]
    G -- Yes --> I{HAS_CN_API_KEY == true?}
    I -- Yes --> J[Run step\ndependabot with key present]
    I -- No --> K[SKIP step\ndependabot without CN_API_KEY]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[tauri-crabnebula job starts] --> B{Linux runner?}
    B -- Yes --> C[Run via xvfb-run]
    B -- No --> D{macOS runner?}
    D -- No: Windows --> F[Run step\nWindows needs no key]
    D -- Yes --> G{actor is dependabot-bot?}
    G -- No --> H[Run step\nnon-dependabot, fails loudly if key missing]
    G -- Yes --> I{HAS_CN_API_KEY == true?}
    I -- Yes --> J[Run step\ndependabot with key present]
    I -- No --> K[SKIP step\ndependabot without CN_API_KEY]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["ci(tauri): skip CrabNebula macOS cell on..."](https://github.com/goosewobbler/wdio-desktop-mobile-example/commit/72d9cb77c04c2d52da7b33e44bb71df650e7060d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39802394)</sub>

<!-- /greptile_comment -->